### PR TITLE
DotParser: remove redundant debug prints

### DIFF
--- a/DotParserProject/DotParserProject/DotLangParser.fs
+++ b/DotParserProject/DotParserProject/DotLangParser.fs
@@ -34,6 +34,4 @@ let parse (str) =
             ast.ChooseSingleAst()
             translate args ast errors |> ignore
             graphs.[0] // todo: add subgraph support
-
-    graph.PrintAllCollectedData() // todo: move to tests
     graph


### PR DESCRIPTION
There was a complaint about redundant debug prints. https://github.com/YaccConstructor/YaccConstructor/pull/145#issuecomment-193768471
I opened this pull request to `master` to make this change accessible in YaccConstructor projects.
Please copy this commit to `GraphTasks` branch as well.