### PR TITLE
Fixed Graphiz issues

### DIFF
--- a/src/QuickGraph.Graphviz/GraphvizAlgorithm.cs
+++ b/src/QuickGraph.Graphviz/GraphvizAlgorithm.cs
@@ -237,11 +237,16 @@ namespace QuickGraph.Graphviz
             {
                 if (edgeColors[e] != GraphColor.White)
                     continue;
-
-                Output.Write("{0} -> {1} [",
-                    this.vertexIds[e.Source],
-                    this.vertexIds[e.Target]
+                if (this.VisitedGraph.IsDirected)
+                    Output.Write("{0} -> {1} [",
+                        this.vertexIds[e.Source],
+                        this.vertexIds[e.Target]
                     );
+                else
+                    Output.Write("{0} -- {1} [",
+                       this.vertexIds[e.Source],
+                       this.vertexIds[e.Target]
+                   );
 
                 OnFormatEdge(e);
                 Output.WriteLine("];");

--- a/src/QuickGraph.Graphviz/GraphvizExtensions.cs
+++ b/src/QuickGraph.Graphviz/GraphvizExtensions.cs
@@ -108,7 +108,7 @@ this
             Contract.Requires(dot != null);
             Contract.Ensures(Contract.Result<string>() != null);
 
-            var request = WebRequest.Create("http://rise4fun.com/services.svc/ask/agl");
+            var request = WebRequest.Create("http://rise4fun.com/rest/ask/Agl/");
             request.Method = "POST";
             // write dot
             using (var writer = new StreamWriter(request.GetRequestStream()))


### PR DESCRIPTION
Generate '--' for graph and '->' for digraph as per Graphviz documentation. 
See [Graphviz Lexical and Semantic Notes](http://graphviz.org/content/dot-language).

Also fixed URL for generating SVG, to the new API format.