### PR TITLE
Added Clustered Graph interface, class and visualization

### DIFF
--- a/src/QuickGraph.Graphviz/FormatClusterEventArgs.cs
+++ b/src/QuickGraph.Graphviz/FormatClusterEventArgs.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using QuickGraph;
+using QuickGraph.Graphviz.Dot;
+using System.Diagnostics.Contracts;
+
+
+namespace QuickGraph.Graphviz
+{
+    /// <summary>
+    /// A clustered graph event argument.
+    /// </summary>
+    public class FormatClusterEventArgs<TVertex, TEdge> : EventArgs where TEdge : IEdge<TVertex>
+    {
+        private IVertexAndEdgeListGraph<TVertex,TEdge> cluster;
+        private GraphvizGraph graphFormat;
+
+        /// <summary>
+        /// Construct a clustered graph event argument
+        /// </summary>
+        /// <param name="cluster">cluster to send to event handlers</param>
+        /// <param name="graphFormat">cluster formatter</param>
+        /// <exception cref="ArgumentNullException">cluster is a null reference.
+        /// </exception>
+        public FormatClusterEventArgs(IVertexAndEdgeListGraph<TVertex,TEdge> cluster, GraphvizGraph graphFormat)
+        {
+            if (cluster == null)
+                throw new ArgumentNullException("cluster");
+            this.cluster = cluster;
+            this.graphFormat = graphFormat;
+        }
+
+        /// <summary>
+        /// Cluster
+        /// </summary>
+        public IVertexAndEdgeListGraph<TVertex,TEdge> Cluster
+        {
+            get
+            {
+                return cluster;
+            }
+        }
+
+        /// <summary>
+        /// Cluster format
+        /// </summary>
+        public GraphvizGraph GraphFormat
+        {
+            get
+            {
+                return graphFormat;
+            }
+        }
+    }
+
+
+    public delegate void FormatClusterEventHandler<TVertex, TEdge>(
+        Object sender,
+        FormatClusterEventArgs<TVertex,TEdge> e)
+        where TEdge: IEdge<TVertex>;
+
+}

--- a/src/QuickGraph.Graphviz/GraphvizAlgorithm.cs
+++ b/src/QuickGraph.Graphviz/GraphvizAlgorithm.cs
@@ -20,7 +20,7 @@ namespace QuickGraph.Graphviz
         private StringWriter output;
         private GraphvizImageType imageType;
         private readonly Dictionary<TVertex, int> vertexIds = new Dictionary<TVertex, int>();
-
+        private int clusterCount;
         private GraphvizGraph graphFormat;
         private GraphvizVertex commonVertexFormat;
         private GraphvizEdge commonEdgeFormat;
@@ -38,6 +38,7 @@ namespace QuickGraph.Graphviz
             Contract.Requires(g != null);
             Contract.Requires(!String.IsNullOrEmpty(path));
 
+            this.clusterCount = 0;
             this.visitedGraph = g;
             this.imageType = imageType;
             this.graphFormat = new GraphvizGraph();
@@ -113,24 +114,34 @@ namespace QuickGraph.Graphviz
                 imageType = value;
             }
         }
-/*
-        /// <summary>
-        /// Event raised while drawing a cluster
-        /// </summary>
-        public event FormatClusterEventHandler<Vertex,Edge> FormatCluster;
-        private void OnFormatCluster(IVertexAndEdgeListGraph<Vertex,Edge> cluster)
+
+        internal int ClusterCount
+        {
+            get
+            {
+                return clusterCount;
+            }
+            set
+            {
+                clusterCount = value;
+            }
+        }
+
+
+       public event FormatClusterEventHandler<TVertex,TEdge> FormatCluster;
+        private void OnFormatCluster(IVertexAndEdgeListGraph<TVertex,TEdge> cluster)
         {
             if (FormatCluster != null)
             {
-                FormatClusterEventArgs<Vertex,Edge> args =
-                    new FormatClusterEventArgs<Vertex,Edge>(cluster, new GraphvizGraph());
+                FormatClusterEventArgs<TVertex,TEdge> args =
+                    new FormatClusterEventArgs<TVertex,TEdge>(cluster, new GraphvizGraph());
                 FormatCluster(this, args);
                 string s = args.GraphFormat.ToDot();
                 if (s.Length != 0)
                     Output.WriteLine(s);
             }
-        }
-*/
+      }
+
         public event FormatVertexEventHandler<TVertex> FormatVertex;
         private void OnFormatVertex(TVertex v)
         {

--- a/src/QuickGraph.Graphviz/GraphvizAlgorithm.cs
+++ b/src/QuickGraph.Graphviz/GraphvizAlgorithm.cs
@@ -219,6 +219,47 @@ namespace QuickGraph.Graphviz
             var output = this.Generate();
             return dot.Run(ImageType, Output.ToString(), outputFileName);
         }
+        internal void WriteClusters (
+        IDictionary<TVertex, GraphColor> colors,
+        IDictionary<TEdge, GraphColor> edgeColors,
+        IClusteredGraph parent
+    ) 
+        {
+            ++ClusterCount;
+            foreach (IVertexAndEdgeListGraph<TVertex,TEdge> g in parent.Clusters)
+            {
+                Output.Write("subgraph cluster{0}", ClusterCount.ToString());
+                Output.WriteLine(" {");
+
+                OnFormatCluster(g);
+
+                if (g is IClusteredGraph)
+                    WriteClusters(colors, edgeColors, g as IClusteredGraph);
+
+                if (parent.Colapsed)
+                {
+                    // draw cluster
+                    // put vertices as black
+                    foreach (TVertex v in g.Vertices)
+                    {
+                        colors[v] = GraphColor.Black;
+
+                    }
+                    foreach (TEdge e in g.Edges)
+                        edgeColors[e] = GraphColor.Black;
+
+                    // add fake vertex
+
+                }
+                else
+                {
+                    WriteVertices(colors, g.Vertices);
+                    WriteEdges(edgeColors, g.Edges);
+                }
+
+                Output.WriteLine("}");
+            }
+        }
 
         private void WriteVertices(
             IDictionary<TVertex,GraphColor> colors,

--- a/src/QuickGraph.Graphviz/GraphvizAlgorithm.cs
+++ b/src/QuickGraph.Graphviz/GraphvizAlgorithm.cs
@@ -172,6 +172,7 @@ namespace QuickGraph.Graphviz
 
         public string Generate()
         {
+            ClusterCount = 0;
             this.vertexIds.Clear();
             this.output = new StringWriter();
             // build vertex id map
@@ -203,6 +204,9 @@ namespace QuickGraph.Graphviz
             var edgeColors = new Dictionary<TEdge, GraphColor>();
             foreach (var e in VisitedGraph.Edges)
                 edgeColors[e] = GraphColor.White;
+
+            if (VisitedGraph is IClusteredGraph)
+                WriteClusters(colors, edgeColors, VisitedGraph as IClusteredGraph);
 
             WriteVertices(colors, VisitedGraph.Vertices);
             WriteEdges(edgeColors, VisitedGraph.Edges);

--- a/src/QuickGraph.Graphviz/QuickGraph.Graphviz.csproj
+++ b/src/QuickGraph.Graphviz/QuickGraph.Graphviz.csproj
@@ -205,6 +205,7 @@
     <Compile Include="Dot\GraphvizVertexStyle.cs" />
     <Compile Include="EdgeMergeCondensatedGraphRenderer.cs" />
     <Compile Include="FileDotEngine.cs" />
+    <Compile Include="FormatClusterEventArgs.cs" />
     <Compile Include="FormatEdgeEventArgs.cs" />
     <Compile Include="FormatVertexEventArgs.cs" />
     <Compile Include="GraphRendererBase.cs" />

--- a/src/QuickGraph/ClusteredAdjacencyGraph.cs
+++ b/src/QuickGraph/ClusteredAdjacencyGraph.cs
@@ -16,10 +16,6 @@ namespace QuickGraph
     public class ClusteredAdjacencyGraph<TVertex, TEdge>
         : IVertexAndEdgeListGraph<TVertex, TEdge>
         , IEdgeListAndIncidenceGraph<TVertex, TEdge>
-        /*, IMutableEdgeListGraph<TVertex, TEdge>
-         , IMutableIncidenceGraph<TVertex, TEdge>
-         , IMutableVertexListGraph<TVertex, TEdge>
-         , IMutableVertexAndEdgeListGraph<TVertex, TEdge>*/
         , IClusteredGraph
         where TEdge : IEdge<TVertex>
     {
@@ -372,12 +368,6 @@ namespace QuickGraph
             return edgeToRemoveCount;
         }
 
-        /* public void TrimEdgeExcess()
-         {
-             wrapped.TrimEdgeExcess();
-             if (parent != null)
-                 parent.TrimEdgeExcess();
-         }*/
 
         public void Clear()
         {

--- a/src/QuickGraph/ClusteredAdjacencyGraph.cs
+++ b/src/QuickGraph/ClusteredAdjacencyGraph.cs
@@ -16,10 +16,10 @@ namespace QuickGraph
     public class ClusteredAdjacencyGraph<TVertex, TEdge>
         : IVertexAndEdgeListGraph<TVertex, TEdge>
         , IEdgeListAndIncidenceGraph<TVertex, TEdge>
-       /*, IMutableEdgeListGraph<TVertex, TEdge>
-        , IMutableIncidenceGraph<TVertex, TEdge>
-        , IMutableVertexListGraph<TVertex, TEdge>
-        , IMutableVertexAndEdgeListGraph<TVertex, TEdge>*/
+        /*, IMutableEdgeListGraph<TVertex, TEdge>
+         , IMutableIncidenceGraph<TVertex, TEdge>
+         , IMutableVertexListGraph<TVertex, TEdge>
+         , IMutableVertexAndEdgeListGraph<TVertex, TEdge>*/
         , IClusteredGraph
         where TEdge : IEdge<TVertex>
     {
@@ -28,11 +28,6 @@ namespace QuickGraph
         private ArrayList clusters;
         private bool colapsed;
 
-        private readonly bool isDirected = true;
-        private readonly bool allowParallelEdges;
-        private readonly IVertexEdgeDictionary<TVertex, TEdge> vertexEdges;
-        private int edgeCount = 0;
-        private int edgeCapacity = -1;
         //OK
         public ClusteredAdjacencyGraph(AdjacencyGraph<TVertex, TEdge> wrapped)
         {
@@ -257,11 +252,13 @@ namespace QuickGraph
 
         public virtual bool AddVertex(TVertex v)
         {
-            if (parent.ContainsVertex(v) || parent == null)
-                return false;
-            else
+            if (!(parent == null || parent.ContainsVertex(v)))
+            {
                 parent.AddVertex(v);
-            return wrapped.AddVertex(v);
+                return wrapped.AddVertex(v);
+            }
+            else
+                return wrapped.AddVertex(v);
         }
 
         public virtual int AddVertexRange(IEnumerable<TVertex> vertices)

--- a/src/QuickGraph/ClusteredAdjacencyGraph.cs
+++ b/src/QuickGraph/ClusteredAdjacencyGraph.cs
@@ -1,0 +1,391 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using QuickGraph.Contracts;
+using QuickGraph.Collections;
+
+namespace QuickGraph
+{
+
+#if !SILVERLIGHT
+    [Serializable]
+#endif
+    [DebuggerDisplay("VertexCount = {VertexCount}, EdgeCount = {EdgeCount}")]
+    public class ClusteredAdjacencyGraph<TVertex, TEdge>
+        : IVertexAndEdgeListGraph<TVertex, TEdge>
+        , IEdgeListAndIncidenceGraph<TVertex, TEdge>
+       /*, IMutableEdgeListGraph<TVertex, TEdge>
+        , IMutableIncidenceGraph<TVertex, TEdge>
+        , IMutableVertexListGraph<TVertex, TEdge>
+        , IMutableVertexAndEdgeListGraph<TVertex, TEdge>*/
+        , IClusteredGraph
+        where TEdge : IEdge<TVertex>
+    {
+        private ClusteredAdjacencyGraph<TVertex, TEdge> parent;
+        private AdjacencyGraph<TVertex, TEdge> wrapped;
+        private ArrayList clusters;
+        private bool colapsed;
+
+        private readonly bool isDirected = true;
+        private readonly bool allowParallelEdges;
+        private readonly IVertexEdgeDictionary<TVertex, TEdge> vertexEdges;
+        private int edgeCount = 0;
+        private int edgeCapacity = -1;
+        //OK
+        public ClusteredAdjacencyGraph(AdjacencyGraph<TVertex, TEdge> wrapped)
+        {
+            if (wrapped == null)
+                throw new ArgumentNullException("parent");
+            this.parent = null;
+            this.wrapped = wrapped;
+            this.clusters = new ArrayList();
+            this.colapsed = false;
+        }
+
+
+        public ClusteredAdjacencyGraph(ClusteredAdjacencyGraph<TVertex, TEdge> parent)
+        {
+            if (parent == null)
+                throw new ArgumentNullException("parent");
+            this.parent = parent;
+            this.wrapped = new AdjacencyGraph<TVertex, TEdge>(parent.AllowParallelEdges);
+            this.clusters = new ArrayList();
+        }
+
+
+        public ClusteredAdjacencyGraph<TVertex, TEdge> Parent
+        {
+            get
+            {
+                return parent;
+            }
+        }
+
+
+        public bool Colapsed
+        {
+            get
+            {
+                return colapsed;
+            }
+            set
+            {
+                colapsed = value;
+            }
+        }
+
+
+        protected AdjacencyGraph<TVertex, TEdge> Wrapped
+        {
+            get
+            {
+                return wrapped;
+            }
+        }
+
+
+        public bool IsDirected
+        {
+            get { return wrapped.IsDirected; }
+        }
+
+        public bool AllowParallelEdges
+        {
+            [Pure]
+            get { return wrapped.AllowParallelEdges; }
+        }
+
+        public int EdgeCapacity
+        {
+            get { return wrapped.EdgeCapacity; }
+            set { wrapped.EdgeCapacity = value; }
+        }
+
+        public static Type EdgeType
+        {
+            get { return typeof(TEdge); }
+        }
+
+        public bool IsVerticesEmpty
+        {
+            get { return wrapped.IsVerticesEmpty; }
+        }
+
+        public int VertexCount
+        {
+            get { return wrapped.VertexCount; }
+        }
+
+        public virtual IEnumerable<TVertex> Vertices
+        {
+            get { return wrapped.Vertices; }
+        }
+
+        [Pure]
+        public bool ContainsVertex(TVertex v)
+        {
+            return wrapped.ContainsVertex(v);
+        }
+
+        public bool IsOutEdgesEmpty(TVertex v)
+        {
+            return wrapped.IsOutEdgesEmpty(v);
+        }
+
+        public int OutDegree(TVertex v)
+        {
+            return wrapped.OutDegree(v);
+        }
+
+        public virtual IEnumerable<TEdge> OutEdges(TVertex v)
+        {
+            return wrapped.OutEdges(v);
+        }
+
+        public virtual bool TryGetOutEdges(TVertex v, out IEnumerable<TEdge> edges)
+        {
+            return wrapped.TryGetOutEdges(v, out edges);
+        }
+
+        public TEdge OutEdge(TVertex v, int index)
+        {
+            return wrapped.OutEdge(v, index);
+        }
+
+
+        public bool IsEdgesEmpty
+        {
+            [Pure]
+            get { return wrapped.IsEdgesEmpty; }
+        }
+
+
+        public int EdgeCount
+        {
+            get
+            {
+                return wrapped.EdgeCount;
+            }
+        }
+
+        [ContractInvariantMethod]
+        void ObjectInvariant()
+        {
+            Contract.Invariant(wrapped.EdgeCount >= 0);
+        }
+
+        public virtual IEnumerable<TEdge> Edges
+        {
+            [Pure]
+            get
+            {
+                return wrapped.Edges;
+            }
+        }
+
+        [Pure]
+        public bool ContainsEdge(TVertex source, TVertex target)
+        {
+            return wrapped.ContainsEdge(source, target);
+        }
+
+        [Pure]
+        public bool ContainsEdge(TEdge edge)
+        {
+            return wrapped.ContainsEdge(edge);
+        }
+
+        [Pure]
+        public bool TryGetEdge(
+            TVertex source,
+            TVertex target,
+            out TEdge edge)
+        {
+            return wrapped.TryGetEdge(source, target, out edge);
+        }
+
+        [Pure]
+        public virtual bool TryGetEdges(
+            TVertex source,
+            TVertex target,
+            out IEnumerable<TEdge> edges)
+        {
+            return wrapped.TryGetEdges(source, target, out edges);
+        }
+
+
+        public IEnumerable Clusters
+        {
+            get
+            {
+                return clusters;
+            }
+        }
+
+
+        public int ClustersCount
+        {
+            get
+            {
+                return clusters.Count;
+            }
+        }
+
+
+        public ClusteredAdjacencyGraph<TVertex, TEdge> AddCluster()
+        {
+            ClusteredAdjacencyGraph<TVertex, TEdge> cluster = new ClusteredAdjacencyGraph<TVertex, TEdge>(this);
+            clusters.Add(cluster);
+            return cluster;
+        }
+
+
+        IClusteredGraph IClusteredGraph.AddCluster()
+        {
+            return this.AddCluster();
+        }
+
+
+        public void RemoveCluster(IClusteredGraph cluster)
+        {
+            if (cluster == null)
+                throw new ArgumentNullException("cluster");
+            clusters.Remove(cluster);
+        }
+
+        public virtual bool AddVertex(TVertex v)
+        {
+            if (parent.ContainsVertex(v) || parent == null)
+                return false;
+            else
+                parent.AddVertex(v);
+            return wrapped.AddVertex(v);
+        }
+
+        public virtual int AddVertexRange(IEnumerable<TVertex> vertices)
+        {
+            int count = 0;
+            foreach (var v in vertices)
+                if (wrapped.AddVertex(v))
+                    count++;
+            return count;
+        }
+
+
+        public virtual bool RemoveVertex(TVertex v)
+        {
+            if (!wrapped.ContainsVertex(v))
+                return false;
+            wrapped.RemoveVertex(v);
+            if (parent != null)
+                parent.RemoveVertex(v);
+            return true;
+        }
+
+
+
+        public int RemoveVertexIf(VertexPredicate<TVertex> predicate)
+        {
+            var vertices = new VertexList<TVertex>();
+            foreach (var v in wrapped.Vertices)
+                if (predicate(v))
+                    vertices.Add(v);
+
+            foreach (var v in vertices)
+                wrapped.RemoveVertex(v);
+
+            return vertices.Count;
+        }
+
+        public virtual bool AddVerticesAndEdge(TEdge e)
+        {
+            wrapped.AddVertex(e.Source);
+            wrapped.AddVertex(e.Target);
+            return wrapped.AddEdge(e);
+        }
+
+
+        public int AddVerticesAndEdgeRange(IEnumerable<TEdge> edges)
+        {
+            int count = 0;
+            foreach (var edge in edges)
+                if (wrapped.AddVerticesAndEdge(edge))
+                    count++;
+            return count;
+        }
+
+        public virtual bool AddEdge(TEdge e)
+        {
+            wrapped.AddEdge(e);
+            if (parent != null && !parent.ContainsEdge(e))
+            {
+                parent.AddEdge(e);
+            }
+
+            return true;
+        }
+
+        public int AddEdgeRange(IEnumerable<TEdge> edges)
+        {
+            int count = 0;
+            foreach (var edge in edges)
+                if (wrapped.AddEdge(edge))
+                    count++;
+            return count;
+        }
+
+
+
+        public virtual bool RemoveEdge(TEdge e)
+        {
+            if (!wrapped.ContainsEdge(e))
+                return false;
+            wrapped.RemoveEdge(e);
+            if (parent != null)
+                parent.RemoveEdge(e);
+            return true;
+        }
+
+
+        public int RemoveEdgeIf(EdgePredicate<TVertex, TEdge> predicate)
+        {
+            var edges = new EdgeList<TVertex, TEdge>();
+            foreach (var edge in wrapped.Edges)
+                if (predicate(edge))
+                    edges.Add(edge);
+
+            foreach (var edge in edges)
+                wrapped.RemoveEdge(edge);
+
+            return edges.Count;
+        }
+
+        public void ClearOutEdges(TVertex v)
+        {
+            wrapped.ClearOutEdges(v);
+        }
+
+        public int RemoveOutEdgeIf(TVertex v, EdgePredicate<TVertex, TEdge> predicate)
+        {
+            int edgeToRemoveCount = wrapped.RemoveOutEdgeIf(v, predicate);
+            if (parent != null)
+                parent.RemoveOutEdgeIf(v, predicate);
+            return edgeToRemoveCount;
+        }
+
+        /* public void TrimEdgeExcess()
+         {
+             wrapped.TrimEdgeExcess();
+             if (parent != null)
+                 parent.TrimEdgeExcess();
+         }*/
+
+        public void Clear()
+        {
+            wrapped.Clear();
+            this.clusters.Clear();
+        }
+    }
+}

--- a/src/QuickGraph/IClusteredGraph.cs
+++ b/src/QuickGraph/IClusteredGraph.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuickGraph
+{
+    public interface IClusteredGraph
+    {
+        IEnumerable Clusters { get; }
+
+        int ClustersCount
+        { get; }
+
+        bool Colapsed { get; set; }
+
+        IClusteredGraph AddCluster();
+
+        void RemoveCluster(IClusteredGraph g);
+    }
+}

--- a/src/QuickGraph/QuickGraph.csproj
+++ b/src/QuickGraph/QuickGraph.csproj
@@ -298,6 +298,7 @@
     <Compile Include="Algorithms\ConnectedComponents\WeaklyConnectedComponentsAlgorithm.cs" />
     <Compile Include="ArrayAdjacencyGraph.cs" />
     <Compile Include="BidirectionAdapterGraph.cs" />
+    <Compile Include="ClusteredAdjacencyGraph.cs" />
     <Compile Include="Collections\BinaryHeap.cs" />
     <Compile Include="Collections\ForestDisjointSet.cs" />
     <Compile Include="Collections\EdgeEdgeDictionary.cs" />
@@ -322,6 +323,7 @@
     <Compile Include="ArrayUndirectedGraph.cs" />
     <Compile Include="ArrayBidirectionalGraph.cs" />
     <Compile Include="EquatableTermEdge.cs" />
+    <Compile Include="IClusteredGraph.cs" />
     <Compile Include="ITermBidirectionalGraph.cs" />
     <Compile Include="TermBidirectionalGraph.cs" />
     <Compile Include="TermEdge.cs" />

--- a/tests/QuickGraph.Tests/ClusteredGraphTest.cs
+++ b/tests/QuickGraph.Tests/ClusteredGraphTest.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using QuickGraph;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+
+namespace QuickGraph.Tests
+{
+    [TestClass()]
+    public class ClusteredGraphTest
+    {
+        public bool ContainsVert(ClusteredAdjacencyGraph<int, IEdge<int>> clus,int v)
+        {
+            if (!clus.ContainsVertex(v))
+            {
+                return false;
+            }
+            else if (clus.Parent != null)
+            {
+                ContainsVert(clus.Parent,v);
+            }
+            return true;
+        }
+
+        public bool ContainsEd(ClusteredAdjacencyGraph<int, IEdge<int>> clus, IEdge<int> e)
+        {
+            if (!clus.ContainsEdge(e))
+            {
+                return false;
+            }
+            else if (clus.Parent != null)
+            {
+                ContainsEd(clus.Parent, e);
+            }
+            return true;
+        }
+
+        [TestMethod()]
+        public void ContainsClustVertexTest1()
+        {
+            var ag = new AdjacencyGraph<int, IEdge<int>>();
+            var cl = new ClusteredAdjacencyGraph<int, IEdge<int>>(ag);
+            var cluster1 = cl.AddCluster();
+            cluster1.AddVertex(5);
+            var a = ContainsVert(cl, 5);
+            Assert.IsTrue(a);
+        }
+
+        [TestMethod()]
+        public void ContainsClustEdgeTest1()
+        {
+            var ag = new AdjacencyGraph<int, IEdge<int>>();
+            var cl = new ClusteredAdjacencyGraph<int, IEdge<int>>(ag);
+            var cluster1 = cl.AddCluster();
+            cluster1.AddVertex(5);
+            cluster1.AddVertex(6);
+            var edge = new TaggedEdge<int, int>(5, 7, 1);
+            cluster1.AddEdge(edge);
+            var a = ContainsEd(cl, edge);
+            Assert.IsTrue(a);
+        }
+
+    }
+}
+

--- a/tests/QuickGraph.Tests/QuickGraph.Tests.csproj
+++ b/tests/QuickGraph.Tests/QuickGraph.Tests.csproj
@@ -328,6 +328,7 @@
     <Compile Include="ArrayAdjacencyGraphTVertexTEdgeTest.cs" />
     <Compile Include="Benchmark.cs" />
     <Compile Include="BidirectionalGraphTest.cs" />
+    <Compile Include="ClusteredGraphTest.cs" />
     <Compile Include="Collections\BinaryHeapTest.cs" />
     <Compile Include="Collections\BinaryHeapTPriorityTValueTest.Constructor.g.cs">
       <DependentUpon>BinaryHeapTest.cs</DependentUpon>


### PR DESCRIPTION
ClusteredAdjacencyGraph is class that have 
1)reference to parent cluster
2)structure that contains references on children clusters
3)Instance of AdjacencyGraph class, that contains all vertices and edges belongs to  current cluster
 
Visualization made via Graphviz. Clusters looks like
http://www.graphviz.org/Gallery/directed/cluster.html