### PR TITLE
Use InvariantCulture when formatting floating points

### DIFF
--- a/src/QuickGraph.Graphviz/Dot/GraphvizEdge.cs
+++ b/src/QuickGraph.Graphviz/Dot/GraphvizEdge.cs
@@ -3,6 +3,7 @@ namespace QuickGraph.Graphviz.Dot
     using System;
     using System.Collections;
     using System.Drawing;
+    using System.Globalization;
     using System.IO;
 
     public class GraphvizEdge
@@ -44,6 +45,18 @@ namespace QuickGraph.Graphviz.Dot
                 if (entry.Value is string)
                 {
                     writer.Write("{0}=\"{1}\"", entry.Key.ToString(), entry.Value.ToString());
+                    continue;
+                }
+                if (entry.Value is float)
+                {
+                    float floatValue = (float)entry.Value;
+                    writer.Write("{0}={1}", entry.Key.ToString(), floatValue.ToString(CultureInfo.InvariantCulture));
+                    continue;
+                }
+                if (entry.Value is double)
+                {
+                    double doubleValue = (double)entry.Value;
+                    writer.Write("{0}={1}", entry.Key.ToString(), doubleValue.ToString(CultureInfo.InvariantCulture));
                     continue;
                 }
                 if (entry.Value is GraphvizEdgeDirection)

--- a/src/QuickGraph.Graphviz/Dot/GraphvizGraph.cs
+++ b/src/QuickGraph.Graphviz/Dot/GraphvizGraph.cs
@@ -4,6 +4,7 @@ namespace QuickGraph.Graphviz.Dot
     using System.Collections;
     using System.Collections.Generic;
     using System.Drawing;
+    using System.Globalization;
     using System.IO;
 
     public class GraphvizGraph
@@ -51,6 +52,18 @@ namespace QuickGraph.Graphviz.Dot
                 if (entry.Value is string)
                 {
                     entries.Add(String.Format("{0}=\"{1}\"", entry.Key.ToString(), entry.Value.ToString()));
+                    continue;
+                }
+                if (entry.Value is float)
+                {
+                    float floatValue = (float)entry.Value;
+                    entries.Add(String.Format("{0}={1}", entry.Key.ToString(), floatValue.ToString(CultureInfo.InvariantCulture)));
+                    continue;
+                }
+                if (entry.Value is double)
+                {
+                    double doubleValue = (double)entry.Value;
+                    entries.Add(String.Format("{0}={1}", entry.Key.ToString(), doubleValue.ToString(CultureInfo.InvariantCulture)));
                     continue;
                 }
                 if (entry.Value is Color)

--- a/src/QuickGraph.Graphviz/Dot/GraphvizVertex.cs
+++ b/src/QuickGraph.Graphviz/Dot/GraphvizVertex.cs
@@ -5,6 +5,7 @@ namespace QuickGraph.Graphviz.Dot
     using System.Drawing;
     using System.IO;
     using System.Collections.Generic;
+    using System.Globalization;
 
     public class GraphvizVertex
     {
@@ -51,6 +52,18 @@ namespace QuickGraph.Graphviz.Dot
                 if (entry.Value is string)
                 {
                     writer.Write("{0}=\"{1}\"", entry.Key, entry.Value.ToString());
+                    continue;
+                }
+                if (entry.Value is float)
+                {
+                    float floatValue = (float)entry.Value;
+                    writer.Write("{0}={1}", entry.Key, floatValue.ToString(CultureInfo.InvariantCulture));
+                    continue;
+                }
+                if (entry.Value is double)
+                {
+                    double doubleValue = (double)entry.Value;
+                    writer.Write("{0}={1}", entry.Key, doubleValue.ToString(CultureInfo.InvariantCulture));
                     continue;
                 }
                 if (entry.Value is GraphvizVertexShape)

--- a/tests/QuickGraph.Tests/GraphVizTests.cs
+++ b/tests/QuickGraph.Tests/GraphVizTests.cs
@@ -1,0 +1,113 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using QuickGraph.Graphviz;
+using System.Drawing;
+using System.Globalization;
+using System.Threading;
+
+namespace QuickGraph.Tests
+{
+    [TestClass]
+    public class GraphVizTests
+    {
+        private static CultureInfo oldCulture;
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext context)
+        {
+            oldCulture = Thread.CurrentThread.CurrentCulture;
+
+            // Germany (de-DE) uses comma as decimal separator
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            Thread.CurrentThread.CurrentCulture = oldCulture;
+        }
+
+        [TestMethod]
+        public void CommonVertexFormat_FontSize_UseDecimalPointForFloats()
+        {
+            var graph = new AdjacencyGraph<string, IEdge<string>>(false);
+            graph.AddVerticesAndEdge(new Edge<string>("s", "t"));
+
+            var gv = new GraphvizAlgorithm<string, IEdge<string>>(graph);
+            gv.CommonVertexFormat.Font = new Font(SystemFonts.DefaultFont.FontFamily, emSize: 1.75f);
+
+            var res = gv.Generate();
+
+            StringAssert.Contains(res, "fontsize=1.75", "Formatting floating points should always use dot as decimal separator");
+        }
+
+        [TestMethod]
+        public void CommonVertexFormat_Z_UseDecimalPointForDoubles()
+        {
+            var graph = new AdjacencyGraph<string, IEdge<string>>(false);
+            graph.AddVerticesAndEdge(new Edge<string>("s", "t"));
+
+            var gv = new GraphvizAlgorithm<string, IEdge<string>>(graph);
+            gv.CommonVertexFormat.Z = 1.75;
+
+            var res = gv.Generate();
+
+            StringAssert.Contains(res, "z=1.75", "Formatting floating points should always use dot as decimal separator");
+        }
+
+        [TestMethod]
+        public void CommonEdgeFormat_FontSize_UseDecimalPointForFloats()
+        {
+            var graph = new AdjacencyGraph<string, IEdge<string>>(false);
+            graph.AddVerticesAndEdge(new Edge<string>("s", "t"));
+
+            var gv = new GraphvizAlgorithm<string, IEdge<string>>(graph);
+            gv.CommonEdgeFormat.Font = new Font(SystemFonts.DefaultFont.FontFamily, emSize: 1.75f);
+
+            var res = gv.Generate();
+
+            StringAssert.Contains(res, "fontsize=1.75", "Formatting floating points should always use dot as decimal separator");
+        }
+
+        [TestMethod]
+        public void CommonEdgeFormat_Weight_UseDecimalPointForDoubles()
+        {
+            var graph = new AdjacencyGraph<string, IEdge<string>>(false);
+            graph.AddVerticesAndEdge(new Edge<string>("s", "t"));
+
+            var gv = new GraphvizAlgorithm<string, IEdge<string>>(graph);
+            gv.CommonEdgeFormat.Weight = 1.75;
+
+            var res = gv.Generate();
+
+            StringAssert.Contains(res, "weight=1.75", "Formatting floating points should always use dot as decimal separator");
+        }
+
+        [TestMethod]
+        public void GraphFormat_RankSeparation_UseDecimalPointForDoubles()
+        {
+            var graph = new AdjacencyGraph<string, IEdge<string>>(false);
+            graph.AddVerticesAndEdge(new Edge<string>("s", "t"));
+
+            var gv = new GraphvizAlgorithm<string, IEdge<string>>(graph);
+            gv.GraphFormat.RankSeparation = 0.75d;
+
+            var res = gv.Generate();
+
+            StringAssert.Contains(res, "ranksep=0.75", "Formatting floating points should always use dot as decimal separator");
+        }
+
+        [TestMethod]
+        public void GraphFormat_FontSize_UseDecimalPointForFloats()
+        {
+            var graph = new AdjacencyGraph<string, IEdge<string>>(false);
+            graph.AddVerticesAndEdge(new Edge<string>("s", "t"));
+
+            var gv = new GraphvizAlgorithm<string, IEdge<string>>(graph);
+            gv.GraphFormat.Font = new Font(SystemFonts.DefaultFont.FontFamily, emSize: 1.75f);
+
+            var res = gv.Generate();
+
+            StringAssert.Contains(res, "fontsize=1.75", "Formatting floating points should always use dot as decimal separator");
+        }
+    }
+}

--- a/tests/QuickGraph.Tests/QuickGraph.Tests.csproj
+++ b/tests/QuickGraph.Tests/QuickGraph.Tests.csproj
@@ -478,6 +478,7 @@
     <Compile Include="GraphExtensionsTest.ToAdjacencyGraph04.g.cs">
       <DependentUpon>GraphExtensionsTest.cs</DependentUpon>
     </Compile>
+    <Compile Include="GraphVizTests.cs" />
     <Compile Include="MutableVertexAndEdgeListGraphTest.cs" />
     <Compile Include="Properties\PexAssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
This PR fixes generating dot files when:
* using floating points, and 
* the `CultureInfo.CurrentCulture` uses comma as decimal separator.

This fixes #192 